### PR TITLE
Italian localization for the 'step' field

### DIFF
--- a/src/localization/messages_it.js
+++ b/src/localization/messages_it.js
@@ -23,5 +23,6 @@ $.extend( $.validator.messages, {
 	nifES: "Inserisci un NIF valido",
 	nieES: "Inserisci un NIE valido",
 	cifES: "Inserisci un CIF valido",
-	currency: "Inserisci una valuta valida"
+	currency: "Inserisci una valuta valida",
+    step: $.validator.format("Inserisci un multiplo di {0}")
 } );


### PR DESCRIPTION
Added the localization of the 'step' message in Italian language

#### Description
Very simple.
Added:
`
$.extend( $.validator.messages, {
    /* ... */
        step: $.validator.format("Inserisci un multiplo di {0}")
} );`
